### PR TITLE
feat: Update background to modern gray with subtle texture

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,4 +1,6 @@
 body{
     background: var(--background-color);
+    background-image: url('./assets/texture.svg');
+    background-repeat: repeat;
     padding: 0 15px;
 }

--- a/src/assets/texture.svg
+++ b/src/assets/texture.svg
@@ -1,0 +1,10 @@
+<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+  <filter id="noiseFilter">
+    <feTurbulence 
+      type="fractalNoise" 
+      baseFrequency="0.65" 
+      numOctaves="3" 
+      stitchTiles="stitch"/>
+  </filter>
+  <rect width="100%" height="100%" filter="url(#noiseFilter)"/>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,7 @@
 @import "https://fonts.googleapis.com/css2?family=Poppins:wght@200;300;400;500;600;700;800;900&display=swap";
 
 :root {
-  --background-color: #121212;
+  --background-color: #333333;
   --text-color: #FFFFFF;
   --primary-color: #BB86FC;
   --secondary-color: #03DAC6;
@@ -9,7 +9,7 @@
 }
 
 body[data-theme="light"] {
-  --background-color: #FFFFFF;
+  --background-color: #E0E0E0;
   --text-color: #000000;
   --primary-color: #6200EE;
   --secondary-color: #03DAC6;


### PR DESCRIPTION
Updated the application's background to a modern gray color scheme with a subtle SVG-based noise texture.

Changes include:
- Modified CSS variables in `src/index.css` to use `#333333` for the dark theme background and `#E0E0E0` for the light theme background.
- Added a new SVG texture asset (`src/assets/texture.svg`).
- Updated `src/App.css` to apply the texture as a repeating background image over the base color.

This provides a more contemporary look and feel to the application across both themes.